### PR TITLE
Compile spamd rules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,13 +95,14 @@ ADD ./build/etc/postfix/master.cf /etc/postfix/master.cf
 RUN service postfix restart; \
     if [ "${BUILD_MYSQL_HOST}" = "localhost" ]; then service mysql restart; fi; \
 # --- 9 Install Amavisd-new, SpamAssassin And Clamav
-    apt-get -y --no-install-recommends install amavisd-new spamassassin clamav clamav-daemon zoo unzip bzip2 arj nomarch lzop cabextract apt-listchanges libnet-ldap-perl libauthen-sasl-perl clamav-docs daemon libio-string-perl libio-socket-ssl-perl libnet-ident-perl zip libnet-dns-perl libdbd-mysql-perl postgrey
+    apt-get -y --no-install-recommends install amavisd-new spamassassin clamav clamav-daemon zoo unzip bzip2 arj nomarch lzop cabextract apt-listchanges libnet-ldap-perl libauthen-sasl-perl clamav-docs daemon libio-string-perl libio-socket-ssl-perl libnet-ident-perl zip libnet-dns-perl libdbd-mysql-perl postgrey gpgv1 gnupg1
 
 ADD ./build/etc/clamav/clamd.conf /etc/clamav/clamd.conf
 RUN chown amavis:amavis /var/run/amavis; \
     freshclam; \
     service spamassassin stop; \
     systemctl disable spamassassin; \
+    sa-update; sa-compile; \
 # --- 10 Install Apache2, PHP5, FCGI, suExec, Pear, And mcrypt
     if [ "${BUILD_MYSQL_HOST}" = "localhost" ]; then service mysql restart; fi; \
     apt-get -y --no-install-recommends install apache2 apache2-doc apache2-utils libapache2-mod-php php7.0 php7.0-common php7.0-gd php7.0-mysql php7.0-imap php7.0-cli php7.0-cgi libapache2-mod-fcgid apache2-suexec-pristine php-pear php7.0-mcrypt mcrypt imagemagick libruby libapache2-mod-python php7.0-curl php7.0-intl php7.0-pspell php7.0-recode php7.0-sqlite3 php7.0-tidy php7.0-xmlrpc php7.0-xsl memcached php-memcache php-imagick php-gettext php7.0-zip php7.0-mbstring memcached libapache2-mod-passenger php7.0-soap; \


### PR DESCRIPTION
```
Dec 13 13:31:31 ispconfig spamd[170]: Can't locate Mail/SpamAssassin/CompiledRegexps/body_0.pm in @INC (you may need to install the Mail::SpamAssassin::CompiledRegexps::body_0 module) (@INC contains: /var/lib/spamassassin/compiled/5.024/3.004002 /var/lib/spamassassin/compiled/5.024/3.004002/auto /usr/share/perl5 /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.24.1 /usr/local/share/perl/5.24.1 /usr/lib/x86_64-linux-gnu/perl5/5.24 /usr/lib/x86_64-linux-gnu/perl/5.24 /usr/share/perl/5.24 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base) at (eval 1221) line 1.
```